### PR TITLE
Flutter spike speech to text

### DIFF
--- a/flutter_spike/android/app/src/main/AndroidManifest.xml
+++ b/flutter_spike/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="fit3170.team4.test_app">
-   <application
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
+    <queries>
+        <intent>
+            <action android:name="android.speech.RecognitionService" />
+        </intent>
+    </queries>
+    <application
         android:label="test_app"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">

--- a/flutter_spike/ios/Runner/Info.plist
+++ b/flutter_spike/ios/Runner/Info.plist
@@ -47,5 +47,9 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>To recognise speech</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>To listen to speech</string>
 </dict>
 </plist>

--- a/flutter_spike/lib/main.dart
+++ b/flutter_spike/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_tts/flutter_tts.dart';
+import 'package:speech_to_text/speech_recognition_result.dart';
+import 'package:speech_to_text/speech_to_text.dart';
 
 void main() {
   runApp(const MyApp());
@@ -49,16 +51,49 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
+  SpeechToText _speechToText = SpeechToText();
+  bool _speechEnabled = false;
+  String _lastWords = '';
 
-  void _incrementCounter() {
+  @override
+  void initState() {
+    super.initState();
+    _initSpeech();
+  }
+
+  /// This has to happen only once per app
+  void _initSpeech() async {
+    print('Initialising speech...');
+    _speechEnabled = await _speechToText.initialize();
+    print('... speech initialised');
+    setState(() {});
+  }
+
+  /// Each time to start a speech recognition session
+  void _startListening() async {
+    print('Starting listening...');
+    await _speechToText.listen(onResult: _onSpeechResult);
+    print('... listening ended');
+    setState(() {});
+  }
+
+  /// Manually stop the active speech recognition session
+  /// Note that there are also timeouts that each platform enforces
+  /// and the SpeechToText plugin supports setting timeouts on the
+  /// listen method.
+  void _stopListening() async {
+    print('Stopping listening...');
+    await _speechToText.stop();
+    print('... stopped listening');
+    setState(() {});
+  }
+
+  /// This is the callback that the SpeechToText plugin calls when
+  /// the platform returns recognized words.
+  void _onSpeechResult(SpeechRecognitionResult result) {
+    print('Received speech result');
     setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
+      _lastWords = result.recognizedWords;
     });
   }
 
@@ -103,14 +138,20 @@ class _MyHomePageState extends State<MyHomePage> {
               child: Text('Say "The quick brown fox jumped over the fence"'),
             ),
 
-            //Voice to Text Button
+            // Speech-to-text text
+            Text('Recognised words: $_lastWords'),
+
+            // Speech-to-text button
             ElevatedButton(
-              onPressed: () {
-                // Add your onPressed code here!
-              },
-              child: const Icon(Icons.record_voice_over),
+              onPressed: _speechToText.isNotListening
+                  ? _startListening
+                  : _stopListening,
+              child: Text(_speechEnabled
+                  ? _speechToText.isListening
+                      ? 'Listening'
+                      : 'Tap to listen'
+                  : 'Speech not enabled'),
             ),
-            Text('Voice Input'),
           ],
         ),
       ),

--- a/flutter_spike/pubspec.lock
+++ b/flutter_spike/pubspec.lock
@@ -96,6 +96,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.8.0"
   lints:
     dependency: transitive
     description:
@@ -136,6 +144,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.11.1"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -149,6 +173,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  speech_to_text:
+    dependency: "direct main"
+    description:
+      name: speech_to_text
+      sha256: ff8fbd31d039bdbac6c7ec9f0516d37df2cbea62c45198326d3b64034e6fb920
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.1"
+  speech_to_text_macos:
+    dependency: transitive
+    description:
+      name: speech_to_text_macos
+      sha256: "6b5575e5a8346be1779838b0a482c259474965b5943668830b479147a75b5bfc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
+  speech_to_text_platform_interface:
+    dependency: transitive
+    description:
+      name: speech_to_text_platform_interface
+      sha256: "13d90215a7554b9a8c1ce47c0a1739af8eacd2cf196ca66351e54dfd2172746d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   stack_trace:
     dependency: transitive
     description:
@@ -199,4 +247,4 @@ packages:
     version: "2.1.4"
 sdks:
   dart: ">=2.19.6 <3.0.0"
-  flutter: ">=1.22.0"
+  flutter: ">=2.5.0"

--- a/flutter_spike/pubspec.yaml
+++ b/flutter_spike/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
     sdk: flutter
 
   flutter_tts: 3.6.3
+  speech_to_text: ^6.1.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
- Add speech-to-text demo on home page of Flutter spike
- Requests required permissions for both Android (tested) and iOS (untested).
- Tap button on home page to start listening to speech, then recognised words should appear in text element above that button.