### PR TITLE
Implement tutorial 2 module 2 (scrolling module)

### DIFF
--- a/application/lib/tutorial/two/module/scroll.dart
+++ b/application/lib/tutorial/two/module/scroll.dart
@@ -1,0 +1,60 @@
+import 'dart:ffi';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+
+class Scroll extends StatelessWidget {
+  const Scroll({Key? key}) : super(key: key);
+  final int _numButtons = 20;
+
+  @override
+  Widget build(BuildContext context) {
+    _speakIntro();
+
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: false, // Disable back button
+        title: const Text("Scrolling Module"),
+      ),
+      body: Center(
+          child: ListView.separated(
+        padding: const EdgeInsets.all(30),
+        itemCount: _numButtons,
+        itemBuilder: (BuildContext context, int index) {
+          return Container(
+            height: 100,
+            padding: const EdgeInsets.symmetric(vertical: 20),
+            child: index == _numButtons - 1
+                ? ElevatedButton(
+                    onPressed: () {
+                      _onSuccess(context);
+                    },
+                    child: const Text('Finish module'))
+                : ElevatedButton(
+                    onPressed: null, child: Text('Button ${index + 1}')),
+          );
+        },
+        separatorBuilder: (BuildContext context, int index) => const Divider(),
+      )),
+    );
+  }
+
+  void _speakIntro() {
+    SemanticsService.announce(
+      "To scroll down, place two fingers on the screen at the same time, then swipe upwards with both of them. To scroll up, swipe with two fingers in the opposite direction. To finish, find the Continue button at the bottom of this vertical menu, then double tap it to continue.",
+      TextDirection.ltr,
+    );
+  }
+
+  void _speakSuccess() {
+    SemanticsService.announce(
+      "You finished this module! Taking you back to the Tutorial.",
+      TextDirection.ltr,
+    );
+  }
+
+  void _onSuccess(BuildContext context) {
+    _speakSuccess();
+    Navigator.pop(context);
+  }
+}

--- a/application/lib/tutorial/two/module/scroll.dart
+++ b/application/lib/tutorial/two/module/scroll.dart
@@ -1,11 +1,9 @@
-import 'dart:ffi';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 
 class Scroll extends StatelessWidget {
   const Scroll({Key? key}) : super(key: key);
-  final int _numButtons = 20;
+  final int _numButtons = 15;
 
   @override
   Widget build(BuildContext context) {
@@ -14,7 +12,7 @@ class Scroll extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false, // Disable back button
-        title: const Text("Scrolling Module"),
+        title: const Text("Vertical Scrolling Module"),
       ),
       body: Center(
           child: ListView.separated(
@@ -31,7 +29,7 @@ class Scroll extends StatelessWidget {
                     },
                     child: const Text('Finish module'))
                 : ElevatedButton(
-                    onPressed: null, child: Text('Button ${index + 1}')),
+                    onPressed: null, child: Text('Item ${index + 1}')),
           );
         },
         separatorBuilder: (BuildContext context, int index) => const Divider(),
@@ -48,6 +46,67 @@ class Scroll extends StatelessWidget {
 
   void _speakSuccess() {
     SemanticsService.announce(
+      "Great! Let's move on to horizontal scrolling.",
+      TextDirection.ltr,
+    );
+  }
+
+  void _onSuccess(BuildContext context) {
+    _speakSuccess();
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => _ScrollHorizontalPage(),
+      ),
+    );
+    // Navigator.pop(context);
+  }
+}
+
+class _ScrollHorizontalPage extends StatelessWidget {
+  final int _numButtons = 10;
+
+  @override
+  Widget build(BuildContext context) {
+    _speakIntro();
+
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: false, // Disable back button
+        title: const Text("Horizontal Scrolling Module"),
+      ),
+      body: Center(
+          child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.all(30),
+        itemCount: _numButtons,
+        itemBuilder: (BuildContext context, int index) {
+          return Container(
+            height: 100,
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: index == _numButtons - 1
+                ? ElevatedButton(
+                    onPressed: () {
+                      _onSuccess(context);
+                    },
+                    child: const Text('Finish module'))
+                : ElevatedButton(
+                    onPressed: null, child: Text('Item ${index + 1}')),
+          );
+        },
+        separatorBuilder: (BuildContext context, int index) => const Divider(),
+      )),
+    );
+  }
+
+  void _speakIntro() {
+    SemanticsService.announce(
+      "To scroll right, swipe left with two fingers. To scroll left, swipe with two fingers in the opposite direction. To finish, first check the checkbox at the end of the horizontal menu, then press the button at the beginning of the horizontal menu.",
+      TextDirection.ltr,
+    );
+  }
+
+  void _speakSuccess() {
+    SemanticsService.announce(
       "You finished this module! Taking you back to the Tutorial.",
       TextDirection.ltr,
     );
@@ -55,6 +114,8 @@ class Scroll extends StatelessWidget {
 
   void _onSuccess(BuildContext context) {
     _speakSuccess();
+    // TODO: This feels very hacky, think we need better routing system...
+    Navigator.pop(context);
     Navigator.pop(context);
   }
 }

--- a/application/lib/tutorial/two/module/scroll.dart
+++ b/application/lib/tutorial/two/module/scroll.dart
@@ -1,41 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 
-class Scroll extends StatelessWidget {
-  const Scroll({Key? key}) : super(key: key);
-  final int _numButtons = 15;
+class ScrollPage extends StatefulWidget {
+  const ScrollPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    _speakIntro();
+  State<ScrollPage> createState() => _ScrollPageState();
+}
 
-    return Scaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false, // Disable back button
-        title: const Text("Vertical Scrolling Module"),
-      ),
-      body: Center(
-          child: ListView.separated(
-        padding: const EdgeInsets.all(30),
-        itemCount: _numButtons,
-        itemBuilder: (BuildContext context, int index) {
-          return Container(
-            height: 100,
-            padding: const EdgeInsets.symmetric(vertical: 20),
-            child: index == _numButtons - 1
-                ? ElevatedButton(
-                    onPressed: () {
-                      _onSuccess(context);
-                    },
-                    child: const Text('Finish module'))
-                : ElevatedButton(
-                    onPressed: null, child: Text('Item ${index + 1}')),
-          );
-        },
-        separatorBuilder: (BuildContext context, int index) => const Divider(),
-      )),
-    );
-  }
+class _ScrollPageState extends State<ScrollPage> {
+  bool _hasSpokenIntro = false; // Whether the intro has been spoken yet
+  final int _numButtons =
+      15; // Number of buttons to list, should be large enough to necessitate scrolling
+  Axis _axis = Axis.vertical; // Axis to align buttons
+  String _successButtonText = "Continue"; // Text to show on last button in list
+  final ButtonStyle _buttonStyle =
+      ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
 
   void _speakIntro() {
     SemanticsService.announce(
@@ -44,63 +24,9 @@ class Scroll extends StatelessWidget {
     );
   }
 
-  void _speakSuccess() {
+  void _speakHorizontal() {
     SemanticsService.announce(
-      "Great! Let's move on to horizontal scrolling.",
-      TextDirection.ltr,
-    );
-  }
-
-  void _onSuccess(BuildContext context) {
-    _speakSuccess();
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => _ScrollHorizontalPage(),
-      ),
-    );
-    // Navigator.pop(context);
-  }
-}
-
-class _ScrollHorizontalPage extends StatelessWidget {
-  final int _numButtons = 10;
-
-  @override
-  Widget build(BuildContext context) {
-    _speakIntro();
-
-    return Scaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false, // Disable back button
-        title: const Text("Horizontal Scrolling Module"),
-      ),
-      body: Center(
-          child: ListView.separated(
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.all(30),
-        itemCount: _numButtons,
-        itemBuilder: (BuildContext context, int index) {
-          return Container(
-            height: 100,
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            child: index == _numButtons - 1
-                ? ElevatedButton(
-                    onPressed: () {
-                      _onSuccess(context);
-                    },
-                    child: const Text('Finish module'))
-                : ElevatedButton(
-                    onPressed: null, child: Text('Item ${index + 1}')),
-          );
-        },
-        separatorBuilder: (BuildContext context, int index) => const Divider(),
-      )),
-    );
-  }
-
-  void _speakIntro() {
-    SemanticsService.announce(
-      "To scroll right, swipe left with two fingers. To scroll left, swipe with two fingers in the opposite direction. To finish, first check the checkbox at the end of the horizontal menu, then press the button at the beginning of the horizontal menu.",
+      "To scroll right, swipe left with two fingers. To scroll left, swipe with two fingers in the opposite direction. To finish, tap the Finish button at the far right of this page.",
       TextDirection.ltr,
     );
   }
@@ -112,10 +38,56 @@ class _ScrollHorizontalPage extends StatelessWidget {
     );
   }
 
-  void _onSuccess(BuildContext context) {
+  void _onTapSuccessButton(BuildContext context) {
+    if (_axis == Axis.vertical) {
+      setState(() {
+        _axis = Axis.horizontal;
+        _successButtonText = "Finish";
+      });
+      _speakHorizontal();
+      return;
+    }
+
     _speakSuccess();
-    // TODO: This feels very hacky, think we need better routing system...
     Navigator.pop(context);
-    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Speak intro if first time opening this page.
+    if (!_hasSpokenIntro) {
+      _speakIntro();
+      _hasSpokenIntro = true;
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: false, // Disable back button
+        title: const Text("Scrolling Module"),
+      ),
+      body: Center(
+          child: ListView.separated(
+        scrollDirection: _axis,
+        padding: const EdgeInsets.all(30),
+        itemCount: _numButtons,
+        itemBuilder: (BuildContext context, int index) {
+          return Container(
+            height: 100,
+            padding: _axis == Axis.vertical
+                ? const EdgeInsets.symmetric(vertical: 20)
+                : const EdgeInsets.symmetric(horizontal: 20),
+            child: index == _numButtons - 1
+                ? ElevatedButton(
+                    onPressed: () {
+                      _onTapSuccessButton(context);
+                    },
+                    child: Text(_successButtonText))
+                : ElevatedButton(
+                    onPressed: null, child: Text('Item ${index + 1}')),
+          );
+        },
+        separatorBuilder: (BuildContext context, int index) => const Divider(),
+      )),
+    );
   }
 }

--- a/application/lib/tutorial/two/tutorial_two.dart
+++ b/application/lib/tutorial/two/tutorial_two.dart
@@ -1,4 +1,5 @@
 import 'package:application/tutorial/two/module/go_back.dart';
+import 'package:application/tutorial/two/module/scroll.dart';
 import 'package:flutter/material.dart';
 
 class TutorialTwo extends StatelessWidget {
@@ -24,9 +25,14 @@ class TutorialTwo extends StatelessWidget {
               },
               child: const Text("Go Back Module"),
             ),
-            const ElevatedButton(
-              onPressed: null,
-              child: Text("Scrolling Module"),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => const Scroll()),
+                );
+              },
+              child: const Text("Scrolling Module"),
             ),
             const ElevatedButton(
               onPressed: null,

--- a/application/lib/tutorial/two/tutorial_two.dart
+++ b/application/lib/tutorial/two/tutorial_two.dart
@@ -29,7 +29,7 @@ class TutorialTwo extends StatelessWidget {
               onPressed: () {
                 Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (context) => const Scroll()),
+                  MaterialPageRoute(builder: (context) => const ScrollPage()),
                 );
               },
               child: const Text("Scrolling Module"),


### PR DESCRIPTION
- Implement tutorial 2 module 2 (scrolling module) in flutter.
- Starts with vertical scrolling sub-module, where user is expected to scroll to bottom of relatively long list using two-finger swipes to scroll quickly.
- Then repeats this but for horizontal scrolling, ending module once user taps the last button.
- Note: this doesn't actually *enforce* that the user uses quick scrolling, only encourages it. Might be wise to enforce it in the future though.
- Note: May also want to discuss handling of "sub-modules". I handled it using a `StatefulWidget`, but it might be better to create a more abstract/general `SubModule` class that defines a common interface for switching between `SubModule`s (or completing a `Module` upon finishing the last `SubModule`).