### PR TITLE
Tutorial 2 Go Back Module: Use TTS instead of semantics announce service

### DIFF
--- a/application/lib/tutorial/two/module/go_back.dart
+++ b/application/lib/tutorial/two/module/go_back.dart
@@ -6,14 +6,26 @@ class GoBack extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    SemanticsService.announce(
-        "To go back, swipe down then left with one finger in a continuous action. If multi-gestures are enabled, swipe with two fingers from the left or right side of the screen.",
-        TextDirection.ltr);
+    SemanticsService.announce("", TextDirection.ltr);
 
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false, // Disable back button
         title: const Text("Go Back Module"),
+      ),
+      body: Card(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: const <Widget>[
+            ListTile(
+              title: Focus(
+                autofocus: true,
+                child: Text(
+                    'To go back, swipe down then left with one finger in a continuous action. If multi-gestures are enabled, swipe with two fingers from the left or right side of the screen.'),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/application/lib/tutorial/two/module/go_back.dart
+++ b/application/lib/tutorial/two/module/go_back.dart
@@ -1,13 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 
 class GoBack extends StatelessWidget {
   const GoBack({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    SemanticsService.announce("", TextDirection.ltr);
-
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false, // Disable back button


### PR DESCRIPTION
This PR adds a text widget that is autofocussed (i.e. focussed first on the screen) containing the instructions for the Go Back Module in Tutorial 2.

The intention is to provide a way for users to re-read the instructions. Moving away from the semantics service will also hopefully improve compatibility with iOS. @MartyCarroll could you confirm this for me?