### PR TITLE
Remove SemanticsService.announce() from tutorial 2 modules

### DIFF
--- a/application/lib/common/instruction_card.dart
+++ b/application/lib/common/instruction_card.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+/// A styled card to display instructions to a user.
+class InstructionsCard extends StatelessWidget {
+  final String instruction;
+  final double _padding = 10;
+  final double _boxWidth = 5;
+
+  const InstructionsCard({super.key, required this.instruction});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      alignment: Alignment.center,
+      padding: EdgeInsets.all(_padding),
+      decoration: BoxDecoration(
+          border: Border.all(color: Colors.blueAccent, width: _boxWidth)),
+      child: Text(
+        instruction,
+      ),
+    );
+  }
+}

--- a/application/lib/tutorial/two/module/adjust_slider.dart
+++ b/application/lib/tutorial/two/module/adjust_slider.dart
@@ -3,11 +3,11 @@ import 'package:flutter/semantics.dart';
 import 'dart:io' show Platform;
 
 class AdjustSliderState extends State<AdjustSlider> {
-  @override
   double _currentValue = 0;
   int stage = 1;
   String displayText = "";
 
+  @override
   Widget build(BuildContext context) {
     if (stage == 1 && _currentValue == 100) {
       // Finished first part
@@ -29,7 +29,8 @@ class AdjustSliderState extends State<AdjustSlider> {
         body: Center(
             child: Column(children: [
           Text(displayText),
-          Text(_currentValue.toStringAsFixed(0), style: TextStyle(fontSize: 30)),
+          Text(_currentValue.toStringAsFixed(0),
+              style: const TextStyle(fontSize: 30)),
           Slider(
               value: _currentValue,
               onChanged: (value) {
@@ -43,20 +44,14 @@ class AdjustSliderState extends State<AdjustSlider> {
 
   String instructions(stage) {
     if (stage == 1) {
-      return """Welcome, in this module you'll learn how to  increase and decrease slider value. A slider is a track that
-          contains values between a minimum and a maximum. Sliders are often used to adjust times. For example: song times
-          or video times. You can also adjust this phone's volume using a slider. To start you will try and increase a slider's
-          value. To increase the value, swipe up. To continue, increase the slider value to 100%""";
+      return "Welcome, in this module you'll learn how to  increase and decrease slider value. A slider is a track that contains values between a minimum and a maximum. Sliders are often used to adjust times. For example: song times or video times. You can also adjust this phone's volume using a slider. To start you will try and increase a slider's value. To increase the value, swipe up. To continue, increase the slider value to 100%";
     } else if (stage == 2) {
-      return """Now we will try and move the slider back down. To do this swipe down with one finger to reduce the value.
-                  Continue until the value is back to 50%""";
+      return "Now we will try and move the slider back down. To do this swipe down with one finger to reduce the value. Continue until the value is back to 50%";
     } else if (stage == 3) {
-      return """An alternative way of changing the volume is to double tap and hold the slider. From here you
-                  can swipe left and right to adjust it in that direction. Try and go back to 100%""";
-    } //  Stage == 3
-    else {
+      return "An alternative way of changing the volume is to double tap and hold the slider. From here you can swipe left and right to adjust it in that direction. Try and go back to 100%";
+    } else {
       //stage == 4
-      return """Nice job! Use the back button to return home""";
+      return "Nice job! Use the back button to return home";
     }
   }
 }
@@ -64,7 +59,6 @@ class AdjustSliderState extends State<AdjustSlider> {
 class AdjustSlider extends StatefulWidget {
   @override
   State<StatefulWidget> createState() {
-    // TODO: implement createState
     return AdjustSliderState();
   }
 }

--- a/application/lib/tutorial/two/module/adjust_slider.dart
+++ b/application/lib/tutorial/two/module/adjust_slider.dart
@@ -1,64 +1,106 @@
-import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
-import 'dart:io' show Platform;
+import 'dart:developer';
 
-class AdjustSliderState extends State<AdjustSlider> {
+import 'package:application/common/instruction_card.dart';
+import 'package:application/routes.dart';
+import 'package:flutter/material.dart';
+
+class AdjustSlider extends _AdjustSlider {
+  const AdjustSlider({super.key})
+      : super(
+            desiredValue: 100,
+            startValue: 0,
+            instruction:
+                "Welcome, in this module you'll learn how to  increase and decrease slider value. A slider is a track that contains values between a minimum and a maximum. Sliders are often used to adjust times. For example: song times or video times. You can also adjust this phone's volume using a slider. To start you will try and increase a slider's value. To increase the value, swipe up. To continue, increase the slider value to 100%",
+            nextSubmodule: const AdjustSlider2());
+}
+
+class AdjustSlider2 extends _AdjustSlider {
+  const AdjustSlider2({super.key})
+      : super(
+            desiredValue: 50,
+            startValue: 100,
+            instruction:
+                "Now we will try and move the slider back down. To do this swipe down with one finger to reduce the value. Continue until the value is back to 50%",
+            nextSubmodule: const AdjustSlider3());
+}
+
+class AdjustSlider3 extends _AdjustSlider {
+  const AdjustSlider3({super.key})
+      : super(
+            desiredValue: 100,
+            startValue: 50,
+            instruction:
+                "An alternative way of changing the volume is to double tap and hold the slider. From here you can swipe left and right to adjust it in that direction. Try and go back to 100%",
+            nextSubmodule: null);
+}
+
+class _AdjustSlider extends StatefulWidget {
+  final double desiredValue;
+  final double startValue;
+  final String instruction;
+  final double _sliderFontSize = 30;
+  final _AdjustSlider? nextSubmodule;
+
+  const _AdjustSlider(
+      {super.key,
+      required this.desiredValue,
+      required this.startValue,
+      required this.instruction,
+      required this.nextSubmodule});
+
+  @override
+  State<StatefulWidget> createState() {
+    return _SliderSubmoduleState();
+  }
+}
+
+class _SliderSubmoduleState extends State<_AdjustSlider> {
   double _currentValue = 0;
-  int stage = 1;
-  String displayText = "";
+
+  @override
+  void initState() {
+    super.initState();
+    _currentValue = widget.startValue;
+  }
 
   @override
   Widget build(BuildContext context) {
-    if (stage == 1 && _currentValue == 100) {
-      // Finished first part
-      stage = 2;
-    }
-    if (stage == 2 && _currentValue == 50) {
-      // Finished second part
-      stage = 3;
-    }
-    if (stage == 3 && _currentValue == 100) {
-      // Finished third part
-      stage = 4;
-    }
-    displayText = instructions(stage);
     return Scaffold(
         appBar: AppBar(
-          title: const Text('Adjust slider page'),
+          title: const Text('Adjust slider'),
         ),
         body: Center(
             child: Column(children: [
-          Text(displayText),
+          InstructionsCard(instruction: widget.instruction),
+          // Round to zero decimal places to avoid floating point issues
           Text(_currentValue.toStringAsFixed(0),
-              style: const TextStyle(fontSize: 30)),
+              style: TextStyle(fontSize: widget._sliderFontSize)),
           Slider(
               value: _currentValue,
               onChanged: (value) {
-                setState(() => {_currentValue = value});
+                setState(() {
+                  _currentValue = value;
+                  if (value.toInt() == widget.desiredValue.toInt()) {
+                    log("Here?");
+                    if (widget.nextSubmodule != null) {
+                      log("Going to next submodule?");
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            // Note '!' because nextSubmodule is nullable, see https://dart.dev/tools/non-promotion-reasons#property-or-this
+                            builder: (context) => widget.nextSubmodule!),
+                      );
+                    } else {
+                      log("Finished tutorial!");
+                      Navigator.popUntil(
+                          context, ModalRoute.withName(Routes.tutorialTwo));
+                    }
+                  }
+                });
               },
               min: 0,
               divisions: 10,
               max: 100)
         ])));
-  }
-
-  String instructions(stage) {
-    if (stage == 1) {
-      return "Welcome, in this module you'll learn how to  increase and decrease slider value. A slider is a track that contains values between a minimum and a maximum. Sliders are often used to adjust times. For example: song times or video times. You can also adjust this phone's volume using a slider. To start you will try and increase a slider's value. To increase the value, swipe up. To continue, increase the slider value to 100%";
-    } else if (stage == 2) {
-      return "Now we will try and move the slider back down. To do this swipe down with one finger to reduce the value. Continue until the value is back to 50%";
-    } else if (stage == 3) {
-      return "An alternative way of changing the volume is to double tap and hold the slider. From here you can swipe left and right to adjust it in that direction. Try and go back to 100%";
-    } else {
-      //stage == 4
-      return "Nice job! Use the back button to return home";
-    }
-  }
-}
-
-class AdjustSlider extends StatefulWidget {
-  @override
-  State<StatefulWidget> createState() {
-    return AdjustSliderState();
   }
 }

--- a/application/lib/tutorial/two/module/explore_menu.dart
+++ b/application/lib/tutorial/two/module/explore_menu.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 
 class ExploreMenuPage extends StatefulWidget {
   const ExploreMenuPage({super.key});
@@ -9,17 +8,11 @@ class ExploreMenuPage extends StatefulWidget {
 }
 
 class _ExploreMenuPageState extends State<ExploreMenuPage> {
-  final BorderSide _borderSideStyle =
+  static const BorderSide _borderSideStyle =
       BorderSide(width: 2.0, color: Colors.black);
-  final String _intro_text =
+  static const String _introText =
       "Welcome! In this module, you will learn how to use explore by touch. You can select different elements by holding your finger on the screen and moving it over another element you'd like to select. To complete the lesson, use explore by touch to find the Finish Lesson button. Remember to drag your finger in any direction slowly around screen, and make sure your finger is touching the screen at all times. You may now start.";
-
-  void _speakSuccess() {
-    SemanticsService.announce(
-      "You have completed the lesson. Sending you to the lesson page.",
-      TextDirection.ltr,
-    );
-  }
+  static const String _finishButtonText = 'Finish Lesson';
 
   // Define the list of button titles
   List<String> buttonTitles = [
@@ -33,7 +26,7 @@ class _ExploreMenuPageState extends State<ExploreMenuPage> {
     'Cricket',
     'March',
     'Elderberry',
-    'Finish Lesson',
+    _finishButtonText,
     'May',
   ];
 
@@ -53,8 +46,8 @@ class _ExploreMenuPageState extends State<ExploreMenuPage> {
               padding: const EdgeInsets.all(10),
               decoration: BoxDecoration(
                   border: Border.all(color: Colors.blueAccent, width: 5)),
-              child: Text(
-                _intro_text,
+              child: const Text(
+                _introText,
               ),
             ),
             Expanded(
@@ -75,25 +68,25 @@ class _ExploreMenuPageState extends State<ExploreMenuPage> {
 
                 // Apply different border styles based on the row position
                 final borderStyle = isLastRow && isLastColumn
-                    ? Border(
+                    ? const Border(
                         top: _borderSideStyle,
                         left: _borderSideStyle,
                         bottom: _borderSideStyle,
                         right: _borderSideStyle,
                       )
                     : isLastColumn
-                        ? Border(
+                        ? const Border(
                             top: _borderSideStyle,
                             left: _borderSideStyle,
                             right: _borderSideStyle,
                           )
                         : isLastRow
-                            ? Border(
+                            ? const Border(
                                 top: _borderSideStyle,
                                 left: _borderSideStyle,
                                 bottom: _borderSideStyle,
                               )
-                            : Border(
+                            : const Border(
                                 top: _borderSideStyle,
                                 left: _borderSideStyle,
                               );
@@ -105,8 +98,7 @@ class _ExploreMenuPageState extends State<ExploreMenuPage> {
                   child: Center(
                     child: TextButton(
                       onPressed: () {
-                        if (title == 'Finish Lesson') {
-                          _speakSuccess();
+                        if (title == _finishButtonText) {
                           Navigator.pop(context);
                         }
                       },

--- a/application/lib/tutorial/two/module/explore_menu.dart
+++ b/application/lib/tutorial/two/module/explore_menu.dart
@@ -57,7 +57,7 @@ class _ExploreMenuPageState extends State<ExploreMenuPage> {
                 _intro_text,
               ),
             ),
-            new Expanded(
+            Expanded(
                 child: GridView.count(
               // Create a grid with 3 columns. If you change the scrollDirection to
               // horizontal, this produces 2 rows.

--- a/application/lib/tutorial/two/module/explore_menu.dart
+++ b/application/lib/tutorial/two/module/explore_menu.dart
@@ -9,16 +9,10 @@ class ExploreMenuPage extends StatefulWidget {
 }
 
 class _ExploreMenuPageState extends State<ExploreMenuPage> {
-  bool _hasSpokenIntro = false; // Whether the intro has been spoken yet
   final BorderSide _borderSideStyle =
       BorderSide(width: 2.0, color: Colors.black);
-
-  void _speakIntro() {
-    SemanticsService.announce(
-      "Welcome! In this module, you will learn how to use explore by touch. You can select different elements by holding your finger on the screen and moving it over another element you'd like to select. To complete the lesson, use explore by touch to find the Finish Lesson button. Remember to drag your finger in any direction slowly around screen, and make sure your finger is touching the screen at all times. You may now start.",
-      TextDirection.ltr,
-    );
-  }
+  final String _intro_text =
+      "Welcome! In this module, you will learn how to use explore by touch. You can select different elements by holding your finger on the screen and moving it over another element you'd like to select. To complete the lesson, use explore by touch to find the Finish Lesson button. Remember to drag your finger in any direction slowly around screen, and make sure your finger is touching the screen at all times. You may now start.";
 
   void _speakSuccess() {
     SemanticsService.announce(
@@ -38,9 +32,6 @@ class _ExploreMenuPageState extends State<ExploreMenuPage> {
     'Cherry',
     'Cricket',
     'March',
-    'Dewberry',
-    'Dragonfly',
-    'April',
     'Elderberry',
     'Finish Lesson',
     'May',
@@ -48,79 +39,88 @@ class _ExploreMenuPageState extends State<ExploreMenuPage> {
 
   @override
   Widget build(BuildContext context) {
-    // Speak intro if first time opening this page.
-    if (!_hasSpokenIntro) {
-      _speakIntro();
-      _hasSpokenIntro = true;
-    }
-
     return Scaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false, // Disable back button
-        title: const Text("Explore Menu Module"),
-      ),
-      body: GridView.count(
-        // Create a grid with 3 columns. If you change the scrollDirection to
-        // horizontal, this produces 2 rows.
-        crossAxisCount: 3,
-        // Generate widgets with button titles from the list in the desired order.
-        children: buttonTitles.asMap().entries.map((entry) {
-          final int index = entry.key;
-          final String title = entry.value;
-
-          // Check if it is the last row
-          final isLastRow = (index >= buttonTitles.length - 3);
-
-          // Check if it is the last row
-          final isLastColumn = (index % 3 == 2);
-
-          // Apply different border styles based on the row position
-          final borderStyle = isLastRow && isLastColumn
-              ? Border(
-                  top: _borderSideStyle,
-                  left: _borderSideStyle,
-                  bottom: _borderSideStyle,
-                  right: _borderSideStyle,
-                )
-              : isLastColumn
-                  ? Border(
-                      top: _borderSideStyle,
-                      left: _borderSideStyle,
-                      right: _borderSideStyle,
-                    )
-                  : isLastRow
-                      ? Border(
-                          top: _borderSideStyle,
-                          left: _borderSideStyle,
-                          bottom: _borderSideStyle,
-                        )
-                      : Border(
-                          top: _borderSideStyle,
-                          left: _borderSideStyle,
-                        );
-
-          return Container(
-            decoration: BoxDecoration(
-              border: borderStyle,
-            ),
-            child: Center(
-              child: TextButton(
-                onPressed: () {
-                  if (title == 'Finish Lesson') {
-                    _speakSuccess();
-                    Navigator.pop(context);
-                  }
-                },
-                child: Text(
-                  title,
-                  style: Theme.of(context).textTheme.titleLarge,
-                  textAlign: TextAlign.center,
-                ),
+        appBar: AppBar(
+          automaticallyImplyLeading: false, // Disable back button
+          title: const Text("Explore Menu Module"),
+        ),
+        body: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: [
+            Container(
+              alignment: Alignment.center,
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                  border: Border.all(color: Colors.blueAccent, width: 5)),
+              child: Text(
+                _intro_text,
               ),
             ),
-          );
-        }).toList(),
-      ),
-    );
+            new Expanded(
+                child: GridView.count(
+              // Create a grid with 3 columns. If you change the scrollDirection to
+              // horizontal, this produces 2 rows.
+              crossAxisCount: 3,
+              // Generate widgets with button titles from the list in the desired order.
+              children: buttonTitles.asMap().entries.map((entry) {
+                final int index = entry.key;
+                final String title = entry.value;
+
+                // Check if it is the last row
+                final isLastRow = (index >= buttonTitles.length - 3);
+
+                // Check if it is the last row
+                final isLastColumn = (index % 3 == 2);
+
+                // Apply different border styles based on the row position
+                final borderStyle = isLastRow && isLastColumn
+                    ? Border(
+                        top: _borderSideStyle,
+                        left: _borderSideStyle,
+                        bottom: _borderSideStyle,
+                        right: _borderSideStyle,
+                      )
+                    : isLastColumn
+                        ? Border(
+                            top: _borderSideStyle,
+                            left: _borderSideStyle,
+                            right: _borderSideStyle,
+                          )
+                        : isLastRow
+                            ? Border(
+                                top: _borderSideStyle,
+                                left: _borderSideStyle,
+                                bottom: _borderSideStyle,
+                              )
+                            : Border(
+                                top: _borderSideStyle,
+                                left: _borderSideStyle,
+                              );
+
+                return Container(
+                  decoration: BoxDecoration(
+                    border: borderStyle,
+                  ),
+                  child: Center(
+                    child: TextButton(
+                      onPressed: () {
+                        if (title == 'Finish Lesson') {
+                          _speakSuccess();
+                          Navigator.pop(context);
+                        }
+                      },
+                      child: Text(
+                        title,
+                        style: Theme.of(context).textTheme.titleLarge,
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                );
+              }).toList(),
+            )),
+          ],
+        ));
   }
 }

--- a/application/lib/tutorial/two/module/scroll.dart
+++ b/application/lib/tutorial/two/module/scroll.dart
@@ -3,26 +3,8 @@
 // reach a "Finish" button. Once pressed, the lesson ends.
 //
 // VerticalScrollSubmodule is the entry point to this lesson.
+import 'package:application/common/instruction_card.dart';
 import 'package:flutter/material.dart';
-
-class InstructionsCard extends StatelessWidget {
-  final String instruction;
-
-  const InstructionsCard({super.key, required this.instruction});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      alignment: Alignment.center,
-      padding: const EdgeInsets.all(10),
-      decoration:
-          BoxDecoration(border: Border.all(color: Colors.blueAccent, width: 5)),
-      child: Text(
-        instruction,
-      ),
-    );
-  }
-}
 
 class VerticalScrollSubmodule extends _ScrollPage {
   @override

--- a/application/lib/tutorial/two/tutorial_two.dart
+++ b/application/lib/tutorial/two/tutorial_two.dart
@@ -31,7 +31,8 @@ class TutorialTwo extends StatelessWidget {
               onPressed: () {
                 Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (context) => const ScrollPage()),
+                  MaterialPageRoute(
+                      builder: (context) => const VerticalScrollSubmodule()),
                 );
               },
               child: const Text("Scrolling Module"),
@@ -40,7 +41,8 @@ class TutorialTwo extends StatelessWidget {
               onPressed: () {
                 Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (context) => const ExploreMenuPage()),
+                  MaterialPageRoute(
+                      builder: (context) => const ExploreMenuPage()),
                 );
               },
               child: const Text("Explore Menu Module"),

--- a/application/lib/tutorial/two/tutorial_two.dart
+++ b/application/lib/tutorial/two/tutorial_two.dart
@@ -51,10 +51,11 @@ class TutorialTwo extends StatelessWidget {
                 onPressed: () => {
                       Navigator.push(
                         context,
-                        MaterialPageRoute(builder: (context) => AdjustSlider()),
+                        MaterialPageRoute(
+                            builder: (context) => const AdjustSlider()),
                       )
                     },
-                child: Text("Adjust slide module"))
+                child: const Text("Adjust slider module"))
           ],
         ),
       ),


### PR DESCRIPTION
# What's changed
- Remove any calls to `SemanticsService.announce()` in tutorial 2 modules. Tutorial 2's challenge has not been touched since that's being worked on in a separate branch. Specifically modules:
  - Adjust slider.
  - Explore menu.
  - Scroll. 
- Add `InstructionsCard`, a very simply styled text element to display instructions at the top of the module. The style can be changed later to make it a little nicer.
- Refactor "Adjust slider" module to use submodules. Idea here was to avoid dynamic instruction text element, since the user would not know that they need to manually change focus back to the top of the module to hear the updated instructions. Submodules *should* be forcing user to read new instruction in a more semantically obvious way.

# Problems
- I've found that even when navigating to a new route/submodule, the user's focus is not guaranteed to be placed at the top of the new page. I'm not sure why this is happening, but this can be addressed later.