### PR TITLE
Add common interface for defining strings

### DIFF
--- a/application/ios/Flutter/Debug.xcconfig
+++ b/application/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/application/ios/Flutter/Release.xcconfig
+++ b/application/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/application/ios/Podfile
+++ b/application/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '11.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/application/lib/common/persistent_storage.dart
+++ b/application/lib/common/persistent_storage.dart
@@ -1,0 +1,10 @@
+// import 'package:shared_preferences/shared_preferences.dart';
+//
+// class SharedPrefService {
+//   static late SharedPreferences pref;
+//
+//   static Future<void> init() async {
+//     pref = await SharedPreferences.getInstance();
+//   }
+// }
+

--- a/application/lib/main.dart
+++ b/application/lib/main.dart
@@ -15,13 +15,13 @@ Future<void> main() async {
   // obtain shared preferences
   final prefs = await SharedPreferences.getInstance();
   int lang = prefs.getInt('language') ?? 0;
-  global.instructions.setLanguage(lang);
+  global.instructions.setLanguage(Language.values[lang]);
 
   runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key key});
+  const MyApp({super.key});
 
   // This widget is the root of your application.
   @override

--- a/application/lib/main.dart
+++ b/application/lib/main.dart
@@ -4,8 +4,16 @@ import 'package:flutter/material.dart';
 import 'package:application/tutorial/tutorial_main.dart';
 import 'package:application/tutorial/two/tutorial_two.dart';
 import 'package:application/tutorial/four/tutorial_four.dart';
+import 'package:application/resources/string/base.dart';
+import 'package:application/select_language.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  // obtain shared preferences
+  final prefs = await SharedPreferences.getInstance();
+  int lang = prefs.getInt('language') ?? 0;
+
   runApp(const MyApp());
 }
 
@@ -15,6 +23,7 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+
     return MaterialApp(
         title: 'Teach Me Talkback',
         theme: ThemeData(
@@ -32,6 +41,7 @@ class MyApp extends StatelessWidget {
         initialRoute: Routes.home,
         routes: {
           Routes.home: (context) => const MyHomePage(title: 'Home Page'),
+          Routes.languageSelect: (context) => const LanguageSelect(),
           Routes.tutorials: (context) => const TutorialMain(),
           Routes.tutorialTwo: (context) => const TutorialTwo(),
           Routes.tutorialFour: (context) => const TutorialFour(),
@@ -64,6 +74,11 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
+    // Handle the language stuff
+    if (LanguageSupport.getLanguage() == Language.english) {
+        Navigator.pushNamed(context, Routes.languageSelect);
+    }
+
     // This method is rerun every time setState is called, for instance as done
     // by the _incrementCounter method above.
     //

--- a/application/lib/main.dart
+++ b/application/lib/main.dart
@@ -6,19 +6,22 @@ import 'package:application/tutorial/two/tutorial_two.dart';
 import 'package:application/tutorial/four/tutorial_four.dart';
 import 'package:application/resources/string/base.dart';
 import 'package:application/select_language.dart';
+import 'package:application/resources/string/base.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:application/resources/string/global.dart' as global;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   // obtain shared preferences
   final prefs = await SharedPreferences.getInstance();
   int lang = prefs.getInt('language') ?? 0;
+  global.instructions.setLanguage(lang);
 
   runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({Key key});
 
   // This widget is the root of your application.
   @override
@@ -40,13 +43,12 @@ class MyApp extends StatelessWidget {
         ),
         initialRoute: Routes.home,
         routes: {
-          Routes.home: (context) => const MyHomePage(title: 'Home Page'),
           Routes.languageSelect: (context) => const LanguageSelect(),
+          Routes.home: (context) => const MyHomePage(title: 'Home Page'),
           Routes.tutorials: (context) => const TutorialMain(),
           Routes.tutorialTwo: (context) => const TutorialTwo(),
           Routes.tutorialFour: (context) => const TutorialFour(),
-          Routes.tutorialSix: (context) => const TutorialSix(),
-        });
+          Routes.tutorialSix: (context) => const TutorialSix(), });
   }
 }
 
@@ -75,9 +77,10 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     // Handle the language stuff
-    if (LanguageSupport.getLanguage() == Language.english) {
-        Navigator.pushNamed(context, Routes.languageSelect);
-    }
+    // Language lang = LanguageSupport.getLanguage();
+    // if (LanguageSupport.getLanguage() == Language.spanish) {
+    //     Navigator.pushNamed(context, Routes.languageSelect);
+    // }
 
     // This method is rerun every time setState is called, for instance as done
     // by the _incrementCounter method above.

--- a/application/lib/resources/string/base.dart
+++ b/application/lib/resources/string/base.dart
@@ -32,54 +32,54 @@ class LanguageSupport<T> {
 }
 
 /// Examples
-
-/// Instantiating an instance for a class of strings
-const LanguageSupport<_Example> _exampleStrings =
-    LanguageSupport(_Example.instances, _Example.english2);
-
-/// Class used as an object enum for strings
-class _Example {
-  /// These can be created from a formatted file
-  static const _Example english = _Example._internal(
-    "First",
-    "Second",
-    "Third",
-  );
-  static const _Example english2 = _Example._internal(
-    "One",
-    "Two",
-    "Three",
-  );
-  static const _Example french = _Example._internal(
-    "1",
-    "2",
-    "3",
-  );
-
-  /// Instances of this class that can be switched between
-  static const Map<Language, _Example> instances = {
-    Language.english: _Example.english,
-    Language.french: _Example.french,
-  };
-
-  final String first;
-  final String second;
-  final String third;
-
-  const _Example._internal(this.first, this.second, this.third);
-}
-
-void main() {
-  // LanguageSupport._setLanguage(Language.english);
-  print(_exampleStrings.getInstance().first);
-  print(_exampleStrings.getInstance().second);
-  print(_exampleStrings.getInstance().third);
-  // LanguageSupport._setLanguage(Language.french);
-  print(_exampleStrings.getInstance().first);
-  print(_exampleStrings.getInstance().second);
-  print(_exampleStrings.getInstance().third);
-  // LanguageSupport._setLanguage(Language.spanish);
-  print(_exampleStrings.getInstance().first);
-  print(_exampleStrings.getInstance().second);
-  print(_exampleStrings.getInstance().third);
-}
+//
+// /// Instantiating an instance for a class of strings
+// const LanguageSupport<_Example> _exampleStrings =
+//     LanguageSupport(_Example.instances, _Example.english2);
+//
+// /// Class used as an object enum for strings
+// class _Example {
+//   /// These can be created from a formatted file
+//   static const _Example english = _Example._internal(
+//     "First",
+//     "Second",
+//     "Third",
+//   );
+//   static const _Example english2 = _Example._internal(
+//     "One",
+//     "Two",
+//     "Three",
+//   );
+//   static const _Example french = _Example._internal(
+//     "1",
+//     "2",
+//     "3",
+//   );
+//
+//   /// Instances of this class that can be switched between
+//   static const Map<Language, _Example> instances = {
+//     Language.english: _Example.english,
+//     Language.french: _Example.french,
+//   };
+//
+//   final String first;
+//   final String second;
+//   final String third;
+//
+//   const _Example._internal(this.first, this.second, this.third);
+// }
+//
+// void main() {
+//   // LanguageSupport._setLanguage(Language.english);
+//   print(_exampleStrings.getInstance().first);
+//   print(_exampleStrings.getInstance().second);
+//   print(_exampleStrings.getInstance().third);
+//   // LanguageSupport._setLanguage(Language.french);
+//   print(_exampleStrings.getInstance().first);
+//   print(_exampleStrings.getInstance().second);
+//   print(_exampleStrings.getInstance().third);
+//   // LanguageSupport._setLanguage(Language.spanish);
+//   print(_exampleStrings.getInstance().first);
+//   print(_exampleStrings.getInstance().second);
+//   print(_exampleStrings.getInstance().third);
+// }

--- a/application/lib/resources/string/base.dart
+++ b/application/lib/resources/string/base.dart
@@ -1,13 +1,15 @@
+/// Supported languages across the application
 enum Language {
   english,
-  french;
+  french,
+  spanish;
 }
 
-/// Base class for any String resources
+/// Wrapper for resources that are language dependent.
 ///
 /// Allows conversion between different implementations of
-/// String resources, such as for different languages.
-abstract class LanguageSupport<T> {
+/// resources for different languages.
+class LanguageSupport<T> {
   static Language _language = Language.english;
 
   static void _setLanguage(Language language) {
@@ -18,41 +20,65 @@ abstract class LanguageSupport<T> {
     return LanguageSupport._language;
   }
 
-  // final T _instance;
+  final Map<Language, T> _instances;
+  final T _default;
+
+  const LanguageSupport(this._instances, this._default);
+
+  T getInstance() {
+    return _instances[LanguageSupport.getLanguage()] ?? this._default;
+  }
 }
 
-class _Example extends LanguageSupport<_Example> {
+/// Examples
+
+/// Instantiating an instance for a class of strings
+const LanguageSupport<_Example> _exampleStrings =
+    LanguageSupport(_Example.instances, _Example.english2);
+
+/// Class used as an object enum for strings
+class _Example {
   /// These can be created from a formatted file
-  static final _Example _english = _Example._internal(
+  static const _Example english = _Example._internal(
     "First",
     "Second",
     "Third",
   );
-  static final _Example _default = _Example._internal(
+  static const _Example english2 = _Example._internal(
     "One",
     "Two",
     "Three",
   );
+  static const _Example french = _Example._internal(
+    "1",
+    "2",
+    "3",
+  );
+
+  /// Instances of this class that can be switched between
+  static const Map<Language, _Example> instances = {
+    Language.english: _Example.english,
+    Language.french: _Example.french,
+  };
 
   final String first;
   final String second;
   final String third;
 
-  _Example._internal(this.first, this.second, this.third);
-
-  factory _Example() {
-    switch (LanguageSupport.getLanguage()) {
-      case Language.english:
-        return _english;
-      default:
-        return _default;
-    }
-  }
+  const _Example._internal(this.first, this.second, this.third);
 }
 
 void main() {
   LanguageSupport._setLanguage(Language.english);
-  print(_Example().first);
-  print(_Example().second);
-  print(_Example().third);
+  print(_exampleStrings.getInstance().first);
+  print(_exampleStrings.getInstance().second);
+  print(_exampleStrings.getInstance().third);
+  LanguageSupport._setLanguage(Language.french);
+  print(_exampleStrings.getInstance().first);
+  print(_exampleStrings.getInstance().second);
+  print(_exampleStrings.getInstance().third);
+  LanguageSupport._setLanguage(Language.spanish);
+  print(_exampleStrings.getInstance().first);
+  print(_exampleStrings.getInstance().second);
+  print(_exampleStrings.getInstance().third);
 }

--- a/application/lib/resources/string/base.dart
+++ b/application/lib/resources/string/base.dart
@@ -1,6 +1,5 @@
 /// Supported languages across the application
 enum Language {
-  unset,
   english,
   french,
   spanish;
@@ -13,11 +12,11 @@ enum Language {
 class LanguageSupport<T> {
   static Language _language = Language.english;
 
-  static void setLanguage(Language language) {
+  void setLanguage(Language language) {
     LanguageSupport._language = language;
   }
 
-  static Language getLanguage() {
+  Language getLanguage() {
     return LanguageSupport._language;
   }
 
@@ -27,7 +26,7 @@ class LanguageSupport<T> {
   const LanguageSupport(this._instances, this._default);
 
   T getInstance() {
-    return _instances[LanguageSupport.getLanguage()] ?? this._default;
+    return _instances[getLanguage()] ?? this._default;
   }
 }
 

--- a/application/lib/resources/string/base.dart
+++ b/application/lib/resources/string/base.dart
@@ -1,5 +1,6 @@
 /// Supported languages across the application
 enum Language {
+  unset,
   english,
   french,
   spanish;
@@ -12,7 +13,7 @@ enum Language {
 class LanguageSupport<T> {
   static Language _language = Language.english;
 
-  static void _setLanguage(Language language) {
+  static void setLanguage(Language language) {
     LanguageSupport._language = language;
   }
 
@@ -69,15 +70,15 @@ class _Example {
 }
 
 void main() {
-  LanguageSupport._setLanguage(Language.english);
+  // LanguageSupport._setLanguage(Language.english);
   print(_exampleStrings.getInstance().first);
   print(_exampleStrings.getInstance().second);
   print(_exampleStrings.getInstance().third);
-  LanguageSupport._setLanguage(Language.french);
+  // LanguageSupport._setLanguage(Language.french);
   print(_exampleStrings.getInstance().first);
   print(_exampleStrings.getInstance().second);
   print(_exampleStrings.getInstance().third);
-  LanguageSupport._setLanguage(Language.spanish);
+  // LanguageSupport._setLanguage(Language.spanish);
   print(_exampleStrings.getInstance().first);
   print(_exampleStrings.getInstance().second);
   print(_exampleStrings.getInstance().third);

--- a/application/lib/resources/string/base.dart
+++ b/application/lib/resources/string/base.dart
@@ -1,0 +1,58 @@
+enum Language {
+  english,
+  french;
+}
+
+/// Base class for any String resources
+///
+/// Allows conversion between different implementations of
+/// String resources, such as for different languages.
+abstract class LanguageSupport<T> {
+  static Language _language = Language.english;
+
+  static void _setLanguage(Language language) {
+    LanguageSupport._language = language;
+  }
+
+  static Language getLanguage() {
+    return LanguageSupport._language;
+  }
+
+  // final T _instance;
+}
+
+class _Example extends LanguageSupport<_Example> {
+  /// These can be created from a formatted file
+  static final _Example _english = _Example._internal(
+    "First",
+    "Second",
+    "Third",
+  );
+  static final _Example _default = _Example._internal(
+    "One",
+    "Two",
+    "Three",
+  );
+
+  final String first;
+  final String second;
+  final String third;
+
+  _Example._internal(this.first, this.second, this.third);
+
+  factory _Example() {
+    switch (LanguageSupport.getLanguage()) {
+      case Language.english:
+        return _english;
+      default:
+        return _default;
+    }
+  }
+}
+
+void main() {
+  LanguageSupport._setLanguage(Language.english);
+  print(_Example().first);
+  print(_Example().second);
+  print(_Example().third);
+}

--- a/application/lib/resources/string/global.dart
+++ b/application/lib/resources/string/global.dart
@@ -1,6 +1,7 @@
 library global;
 import 'package:application/resources/string/base.dart';
 import 'package:xml/xml.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class NestedStrings {
     var _subfolders = new Map<String, NestedStrings>();
@@ -22,8 +23,24 @@ class NestedStrings {
         }
     }
     
-    String getString(String label) {
-        return _strings[label] ?? "error";
+    String getString(String path) {
+        // Split the input on slashes
+        final path_split = path.split("/");
+        if (path_split.length == 1) {
+            return _strings[path_split[0]] ?? "error";
+        }
+        else if (path_split.length > 1) {
+            if (_subfolders == null || _subfolders[path_split[0]] == null) {
+                return "error";
+            }
+            else {
+                return _subfolders[path_split[0]]!.getString(path_split.sublist(1).
+                        join("/"));
+            }
+        }
+        else {
+            return "error";
+        }
     }
 
 }
@@ -47,4 +64,9 @@ LanguageSupport<NestedStrings> generate_languages() {
 }
 
 
+
 LanguageSupport<NestedStrings> instructions = generate_languages();
+
+
+
+

--- a/application/lib/resources/string/global.dart
+++ b/application/lib/resources/string/global.dart
@@ -1,0 +1,50 @@
+library global;
+import 'package:application/resources/string/base.dart';
+import 'package:xml/xml.dart';
+
+class NestedStrings {
+    var _subfolders = new Map<String, NestedStrings>();
+    var _strings = new Map<String, String>();
+
+    void setString(String path, String value) {
+        // Split the input on slashes
+        final path_split = path.split("/");
+        if (path_split.length == 1) {
+            _strings[path_split[0]] = value;
+        }
+        else if (path_split.length > 1) {
+            _subfolders ??= new Map<String, NestedStrings>();
+            _subfolders[path_split[0]] ??= new NestedStrings();
+            _subfolders[path_split[0]]!.setString(path_split.sublist(1).join("/"), value);
+        }
+        else {
+            return;
+        }
+    }
+    
+    String getString(String label) {
+        return _strings[label] ?? "error";
+    }
+
+}
+
+
+
+LanguageSupport<NestedStrings> generate_languages() {
+
+    var temp_map = new Map<Language, NestedStrings>();
+
+    // Create all of our maps from the xml.
+    for (var language in Language.values) {
+        var strings = new NestedStrings();
+        // Generate strings from the xml
+        temp_map[language] = strings;
+    }
+
+    // Instantiate the language objects
+    return LanguageSupport(temp_map, temp_map[Language.english] ??
+            new NestedStrings());
+}
+
+
+LanguageSupport<NestedStrings> instructions = generate_languages();

--- a/application/lib/routes.dart
+++ b/application/lib/routes.dart
@@ -9,6 +9,7 @@ class Routes {
   static const String tutorialFive = "$tutorials/five";
   static const String tutorialSix = "$tutorials/six";
   static const String tutorialSeven = "$tutorials/seven";
+  static const String languageSelect = "$home";
 
   static const String gestures = "$home/gestures";
 }

--- a/application/lib/select_language.dart
+++ b/application/lib/select_language.dart
@@ -1,6 +1,7 @@
 // Page to select a language
 import 'package:flutter/material.dart';
 import 'package:application/resources/string/base.dart';
+import 'package:application/main.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class LanguageSelect extends StatelessWidget {
@@ -19,21 +20,35 @@ class LanguageSelect extends StatelessWidget {
             ElevatedButton(
               onPressed: () {
                 LanguageSupport.setLanguage(Language.english);
-                Navigator.pop();
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) =>
+                        const MyHomePage(title: 'Home Page'))
+                  );
+
               },
               child: Text("English"),
             ),
             ElevatedButton(
               onPressed: () {
                 LanguageSupport.setLanguage(Language.french);
-                Navigator.pop();
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) =>
+                        const MyHomePage(title: 'Home Page'))
+                  );
+
               },
               child: Text("French"),
             ),
             ElevatedButton(
               onPressed: () {
                 LanguageSupport.setLanguage(Language.spanish);
-                Navigator.pop();
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) =>
+                        const MyHomePage(title: 'Home Page'))
+                  );
 
               },
               child: Text("Spanish"),

--- a/application/lib/select_language.dart
+++ b/application/lib/select_language.dart
@@ -1,0 +1,46 @@
+// Page to select a language
+import 'package:flutter/material.dart';
+import 'package:application/resources/string/base.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LanguageSelect extends StatelessWidget {
+  const LanguageSelect({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Select a language"),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: () {
+                LanguageSupport.setLanguage(Language.english);
+                Navigator.pop();
+              },
+              child: Text("English"),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                LanguageSupport.setLanguage(Language.french);
+                Navigator.pop();
+              },
+              child: Text("French"),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                LanguageSupport.setLanguage(Language.spanish);
+                Navigator.pop();
+
+              },
+              child: Text("Spanish"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/application/lib/select_language.dart
+++ b/application/lib/select_language.dart
@@ -3,6 +3,13 @@ import 'package:flutter/material.dart';
 import 'package:application/resources/string/base.dart';
 import 'package:application/main.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:application/resources/string/global.dart' as global;
+
+Future<void> set_language_pref(Language l) async {
+      WidgetsFlutterBinding.ensureInitialized();
+      final prefs = await SharedPreferences.getInstance();
+      prefs.setInt('language', l.index);
+}
 
 class LanguageSelect extends StatelessWidget {
   const LanguageSelect({Key? key}) : super(key: key);
@@ -19,7 +26,8 @@ class LanguageSelect extends StatelessWidget {
           children: [
             ElevatedButton(
               onPressed: () {
-                LanguageSupport.setLanguage(Language.english);
+                set_language_pref(Language.english);
+                
                   Navigator.push(
                     context,
                     MaterialPageRoute(builder: (context) =>
@@ -31,7 +39,7 @@ class LanguageSelect extends StatelessWidget {
             ),
             ElevatedButton(
               onPressed: () {
-                LanguageSupport.setLanguage(Language.french);
+                set_language_pref(Language.french);
                   Navigator.push(
                     context,
                     MaterialPageRoute(builder: (context) =>
@@ -43,7 +51,7 @@ class LanguageSelect extends StatelessWidget {
             ),
             ElevatedButton(
               onPressed: () {
-                LanguageSupport.setLanguage(Language.spanish);
+                set_language_pref(Language.spanish);
                   Navigator.push(
                     context,
                     MaterialPageRoute(builder: (context) =>

--- a/application/macos/Flutter/Flutter-Debug.xcconfig
+++ b/application/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/application/macos/Flutter/Flutter-Release.xcconfig
+++ b/application/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/application/macos/Podfile
+++ b/application/macos/Podfile
@@ -1,0 +1,40 @@
+platform :osx, '10.14'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/application/pubspec.lock
+++ b/application/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.10.0"
   audio_session:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.0"
   crypto:
     dependency: transitive
     description:
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -116,10 +124,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.6.5"
   just_audio:
     dependency: "direct main"
     description:
@@ -156,10 +164,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
@@ -172,18 +180,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.8.2"
   path_provider:
     dependency: transitive
     description:
@@ -264,6 +272,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "0344316c947ffeb3a529eac929e1978fcd37c26be4e8468628bac399365a3ca1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: fe8401ec5b6dcd739a0fe9588802069e608c3fdbfd3c3c93e546cf2f90438076
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: d29753996d8eb8f7619a1f13df6ce65e34bc107bef6330739ed76f18b22310ef
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "71d6806d1449b0a9d4e85e0c7a917771e672a3d5dc61149cc9fac871115018e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "23b052f17a25b90ff2b61aad4cc962154da76fb62848a9ce088efe30d7c50ab1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: "7347b194fb0bbeb4058e6a4e87ee70350b6b2b90f8ac5f8bd5b3a01548f6d33a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: f95e6a43162bce43c9c3405f3eb6f39e5b5d11f65fab19196cf8225e2777624d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -313,10 +377,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.4.16"
   typed_data:
     dependency: transitive
     description:
@@ -366,5 +430,5 @@ packages:
     source: hosted
     version: "6.2.2"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=2.19.6 <3.0.0"
   flutter: ">=3.3.0"

--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -28,6 +28,7 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
+  shared_preferences: any
   flutter:
     sdk: flutter
 
@@ -36,7 +37,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   flutter_tts: ^3.6.3
-  just_audio: ^0.9.13
+  just_audio: any
   xml: ^6.2.2
 
 dev_dependencies:


### PR DESCRIPTION
Defines a common standard for creating string enums (example provided as `_Example`), and a wrapper class used to switch between different language implementations of that class.

Some of the API is user enforced due to some limitations in the type system in Dart 2.0 and prioritising reducing complexity. 