### PR TITLE
Open talkback settings in Android

### DIFF
--- a/application/lib/main.dart
+++ b/application/lib/main.dart
@@ -1,17 +1,21 @@
-import 'package:application/routes.dart';
-import 'package:application/soundboard.dart';
-import 'package:application/tutorial/six/tutorial_six.dart';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:app_settings/app_settings.dart';
+
+import 'package:application/routes.dart';
 import 'package:application/tutorial/two/tutorial_two.dart';
 import 'package:application/tutorial/three/tutorial_three.dart';
 import 'package:application/tutorial/four/tutorial_four.dart';
-import 'package:application/tutorial/seven/tutorial_seven.dart';
 import 'package:application/tutorial/five/tutorial_five.dart';
+import 'package:application/tutorial/six/tutorial_six.dart';
+import 'package:application/tutorial/seven/tutorial_seven.dart';
+import 'package:application/tutorial/eight/tutorial_eight.dart';
 import 'package:application/progression_tracker.dart';
 import 'package:application/sandbox_mode.dart';
 import 'package:application/gesture_game.dart';
-import 'package:easy_localization/easy_localization.dart';
-import 'package:application/tutorial/eight/tutorial_eight.dart';
+import 'package:application/soundboard.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -28,6 +32,7 @@ void main() async {
         ],
         path: 'assets/translations',
         fallbackLocale: const Locale('en'),
+        useFallbackTranslations: true,
         child: const MyApp()),
   );
 }
@@ -89,6 +94,8 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    bool screenReaderIsEnabled = MediaQuery.of(context).accessibleNavigation;
+
     return Scaffold(
       appBar: AppBar(
         title: Text(title).tr(),
@@ -97,6 +104,15 @@ class HomePage extends StatelessWidget {
           child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
+          if (!screenReaderIsEnabled)
+            if (Platform.isAndroid)
+              ElevatedButton(
+                  onPressed: () => AppSettings.openAppSettings(
+                      type: AppSettingsType.accessibility),
+                  child: const Text('Enable Talkback'))
+            else if (Platform.isIOS)
+              const Text(
+                  'You should enable VoiceOver in your settings to best use this app'),
           MainMenuTutorialButton(
               title: 'tutorial'.tr(args: ["2"]), routeName: Routes.tutorialTwo),
           MainMenuTutorialButton(

--- a/application/pubspec.lock
+++ b/application/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.7"
+  app_settings:
+    dependency: "direct main"
+    description:
+      name: app_settings
+      sha256: "09bc7fe0313a507087bec1a3baf555f0576e816a760cbb31813a88890a09d9e5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
   args:
     dependency: transitive
     description:

--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
     sdk: flutter
   intl: any
   easy_localization: any
+  app_settings: ^5.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- If Android user does not have Talkback enabled, then a button appears at top of home page that takes them to accessibility settings page, which contains Talkback switch. When they return to app with Talkback enabled, then that button disappears.
- For iOS, this plugin at least does not let us open the required page in settings, so just show a text element to tell user to open settings.
- This is **untested on iOS** since I don't have macOS. Text is unstyle so will be very ugly but at least it's there

## Quick demo on Android emulator
[talkback_settings_720.webm](https://github.com/Monash-FIT3170/Team4-Android-Talkback/assets/7236870/c43649c7-7170-42a1-a137-b00c3ed4057e)
